### PR TITLE
Fixing the bug

### DIFF
--- a/ch-01-arrays-and-strings/08-zero-matrix.py
+++ b/ch-01-arrays-and-strings/08-zero-matrix.py
@@ -13,7 +13,6 @@ def zero_out_row_col(mat):
       if mat[r][c] == 0:
         zero_rows.append(r)
         zero_cols.append(c)
-        break
   for r in zero_rows:
     for c in xrange(m):
       mat[r][c] = 0


### PR DESCRIPTION
The `break` statement was causing a logic bug. I've just removed it.
Test sample:
```python
[
  [1,2,0],
  [5,6,7],
  [0,0,9]
]
```
Without my fix result is:
```python
[
  [0,0,0],
  [0,6,0],
  [0,0,0]
]
```
After my fix result is correct:
```python
[
  [0,0,0],
  [0,0,0],
  [0,0,0]
]
```