### PR TITLE
Remove break from line 16

### DIFF
--- a/ch-01-arrays-and-strings/08-zero-matrix.py
+++ b/ch-01-arrays-and-strings/08-zero-matrix.py
@@ -13,7 +13,6 @@ def zero_out_row_col(mat):
       if mat[r][c] == 0:
         zero_rows.append(r)
         zero_cols.append(c)
-        break
   for r in zero_rows:
     for c in xrange(m):
       mat[r][c] = 0


### PR DESCRIPTION
There might be other zeroes in the same row, I don't think we can break here as this might result in us missing out some columns that might need to be nullified.

The official solutions do not have a break here as well.